### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/iZone/src/iZone/MainClass.php
+++ b/iZone/src/iZone/MainClass.php
@@ -27,7 +27,6 @@ class MainClass extends PluginBase implements CommandExecutor
     public function onLoad()
     {
         $this->saveDefaultConfig();
-        $this->getResource("config.yml");
     }
 
     /**


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`